### PR TITLE
new request for obtaining statistics in prometheus-like format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ conf_local.json
 conf_remote.json
 .DS_*
 log/
+.devcontainer

--- a/conf.json
+++ b/conf.json
@@ -46,5 +46,6 @@
     "lookup": "../oci/lookup.csv",
     "oci_conf": "../oci/oci.json",
     "intrepid_conf": "../intrepid/intrepid.json"
-  }
+  },
+  "stats_dir": "/srv/web/stats/"
 }

--- a/conf_local.json
+++ b/conf_local.json
@@ -46,5 +46,6 @@
     "lookup": "../oci/lookup.csv",
     "oci_conf": "../oci/oci.json",
     "intrepid_conf": "../intrepid/intrepid.json"
-  }
+  },
+  "stats_dir": "../opencitations-log-stats/examples/"
 }

--- a/conf_remote.json
+++ b/conf_remote.json
@@ -46,5 +46,6 @@
     "lookup": "../oci/lookup.csv",
     "oci_conf": "../oci/oci.json",
     "intrepid_conf": "../intrepid/intrepid.json"
-  }
+  },
+  "stats_dir": "/srv/web/stats/"
 }


### PR DESCRIPTION
With the changes made in this update the management of a new request is added in order to exhibit via API the generated statistics, the configuration of the service requires a single additional entry that indicates the folder in which the statistics are contained, namely `stats_dir`.