### PR TITLE
Fix the check for end of the year in the range statistics loop

### DIFF
--- a/oc.py
+++ b/oc.py
@@ -913,7 +913,7 @@ class Statistics:
                         # If we reaches the target year and the month we are visiting is the last one 
                         # or if we visited the whole year i.e. the last month has just been visited
                         # exit the months's loop
-                        if (current_year == target_year and current_month >= target_month) or target_month == 12:
+                        if (current_year == target_year and current_month >= target_month) or current_month == 12:
                             break
                         current_month += 1
                     


### PR DESCRIPTION
To see if the last month of the year has been visited `current_month`
must be checked, not `target_month`, which does not change in the loop.