### PR TITLE
Correct Order of File Sizes

### DIFF
--- a/html-template/download.html
+++ b/html-template/download.html
@@ -103,8 +103,8 @@ $def with (pages, active)
                 <div class="table-responsive">
                      <table class="table">
                        <tr><th>Type and format</th><th>Archive</th><th>Size</th></tr>
-                       <tr><td>Metadata (CSV)</td><td><a href="https://doi.org/10.6084/m9.figshare.21747461.v8">ZIP</a></td><td>11 GB (46 GB zipped) on ext4</td></tr>
-                       <tr><td>Metadata and provenance (RDF)</td><td><a href="https://doi.org/10.6084/m9.figshare.21747536.v6">XZ (LZMA2 compression algorithm)</a></td><td>29 GB (43 GB compressed) on ext4</td></tr>
+                       <tr><td>Metadata (CSV)</td><td><a href="https://doi.org/10.6084/m9.figshare.21747461.v8">ZIP</a></td><td>46 GB (11 GB zipped) on ext4</td></tr>
+                       <tr><td>Metadata and provenance (RDF)</td><td><a href="https://doi.org/10.6084/m9.figshare.21747536.v6">XZ (LZMA2 compression algorithm)</a></td><td>43 GB (29 GB compressed) on ext4</td></tr>
                      </table>
                 </div>
                 <p>In addition, a CSV dump containing a mapping between all the bibliographic resources identified by an OMID (e.g., br/12345) and their corresponding PID(s) (e.g., DOI, PMID)</p>
@@ -139,7 +139,7 @@ $def with (pages, active)
                          <tr><td>Citation data (CSV)</td><td><a href="https://doi.org/10.6084/m9.figshare.24356626.v2">ZIP</a></td><td>171 GB (26.8 GB zipped)</td></tr>
                          <tr><td>Citation data (N-Triple)</td><td><a href="https://doi.org/10.6084/m9.figshare.24369136.v2">ZIP</a></td><td>1.4 TB (62.3 GB zipped)</td></tr>
                          <tr><td>Citation data (Scholix)</td><td><a href="https://doi.org/10.6084/m9.figshare.24416749.v2">ZIP</a></td><td>1.7 TB (37 GB zipped)</td></tr>
-                         <tr><td>Provenance data (CSV)</td><td><a href="https://doi.org/10.6084/m9.figshare.24417733.v2">ZIP</a></td><td>14 GB (312 GB zipped)</td></tr>
+                         <tr><td>Provenance data (CSV)</td><td><a href="https://doi.org/10.6084/m9.figshare.24417733.v2">ZIP</a></td><td>312 GB (14 GB zipped)</td></tr>
                          <tr><td>Provenance data (N-Triple)</td><td><a href="https://doi.org/10.6084/m9.figshare.24417736.v2">ZIP</a></td><td>2.5 TB (79 GB zipped)</td></tr>
                      </table>
                 </div>


### PR DESCRIPTION
Hello @ivanhb and @arcangelo7! I noticed that a few of the download sizes were flipped between the uncompressed and compressed sizes. This PR updates them to match the `Uncompressed Size (Compressed Size)` convention.

Thanks for the effort in collecting in creating an maintaining this dataset! It is really a wonderful resource!